### PR TITLE
Add validation in contract

### DIFF
--- a/packages/snfoundry/contracts/src/YourCollectible.cairo
+++ b/packages/snfoundry/contracts/src/YourCollectible.cairo
@@ -169,23 +169,25 @@ mod YourCollectible {
                 // To prevent a gap in from's tokens array, we store the last token in the index of the token to delete, and
                 // then delete the last slot (swap and pop).
                 let owner = self.owner_of(token_id);
-                let last_token_index = self.balance_of(owner) - 1;
-                let token_index = enumerable_component.owned_tokens_index.read(token_id);
+                if owner != to {
+                    let last_token_index = self.balance_of(owner) - 1;
+                    let token_index = enumerable_component.owned_tokens_index.read(token_id);
 
-                // When the token to delete is the last token, the swap operation is unnecessary
-                if (token_index != last_token_index) {
-                    let last_token_id = enumerable_component
-                        .owned_tokens
-                        .read((owner, last_token_index));
-                    // Move the last token to the slot of the to-delete token
-                    enumerable_component.owned_tokens.write((owner, token_index), last_token_id);
-                    // Update the moved token's index
-                    enumerable_component.owned_tokens_index.write(last_token_id, token_index);
+                    // When the token to delete is the last token, the swap operation is unnecessary
+                    if (token_index != last_token_index) {
+                        let last_token_id = enumerable_component
+                            .owned_tokens
+                            .read((owner, last_token_index));
+                        // Move the last token to the slot of the to-delete token
+                        enumerable_component.owned_tokens.write((owner, token_index), last_token_id);
+                        // Update the moved token's index
+                        enumerable_component.owned_tokens_index.write(last_token_id, token_index);
+                    }
+
+                    // Clear the last slot
+                    enumerable_component.owned_tokens.write((owner, last_token_index), 0);
+                    enumerable_component.owned_tokens_index.write(token_id, 0);
                 }
-
-                // Clear the last slot
-                enumerable_component.owned_tokens.write((owner, last_token_index), 0);
-                enumerable_component.owned_tokens_index.write(token_id, 0);
             }
             if (to == Zero::zero()) { // `Burn Token` case: Remove token from `all_tokens` enumerable component
                 let last_token_index = enumerable_component.all_tokens_length.read() - 1;


### PR DESCRIPTION
# Task name here
NFT transfer error
Fixes #140 
Closes #140 

## Types of change

- [ ] Feature
- [x] Bug
- [ ] Enhancement

## Comments (optional)
- The bug was caused in lines [187 and 188](https://github.com/Scaffold-Stark/speedrunstark/blob/370102ff3bbb84e34b82765fd0a4af95345e3a4b/packages/snfoundry/contracts/src/YourCollectible.cairo#L187) of `YourCollectible.cairo` contract, when a transfer is performed it set the token index to `0`, this cause in `MyHoldings.tsx` a failure since it returns [here](https://github.com/Scaffold-Stark/speedrunstark/blob/370102ff3bbb84e34b82765fd0a4af95345e3a4b/packages/nextjs/components/SimpleNFT/MyHoldings.tsx#L52) a 0 as the token Id, all this problem can be avoided by validating if the sender and the receiver of the token is the same do nothing.

