### PR TITLE
chore: add retry to addIPfs and getIpfsMetadata

### DIFF
--- a/packages/nextjs/app/ipfsDownload/page.tsx
+++ b/packages/nextjs/app/ipfsDownload/page.tsx
@@ -4,6 +4,7 @@ import { lazy, useEffect, useState } from "react";
 import type { NextPage } from "next";
 import { notification } from "~~/utils/scaffold-stark/notification";
 import { getMetadataFromIPFS } from "~~/utils/simpleNFT/ipfs-fetch";
+import { INITIAL_ATTEMPT, MAX_ATTEMPTS } from "~~/utils/simpleNFT/constants";
 
 const LazyReactJson = lazy(() => import("react-json-view"));
 
@@ -16,11 +17,12 @@ const IpfsDownload: NextPage = () => {
     setMounted(true);
   }, []);
 
+
   const handleIpfsDownload = async () => {
     setLoading(true);
     const notificationId = notification.loading("Getting data from IPFS...");
-    let attempt = 0;
-    const maxAttempts = 2;
+    let attempt = INITIAL_ATTEMPT;
+    const maxAttempts = MAX_ATTEMPTS;
     while (attempt < maxAttempts) {
       try {
         const metaData = await getMetadataFromIPFS(ipfsPath);

--- a/packages/nextjs/app/ipfsDownload/page.tsx
+++ b/packages/nextjs/app/ipfsDownload/page.tsx
@@ -18,20 +18,28 @@ const IpfsDownload: NextPage = () => {
 
   const handleIpfsDownload = async () => {
     setLoading(true);
-    const notificationId = notification.loading("Getting data from IPFS");
-    try {
-      const metaData = await getMetadataFromIPFS(ipfsPath);
-      notification.remove(notificationId);
-      notification.success("Downloaded from IPFS");
-
-      setYourJSON(metaData);
-    } catch (error) {
-      notification.remove(notificationId);
-      notification.error("Error downloading from IPFS");
-      console.log(error);
-    } finally {
-      setLoading(false);
+    const notificationId = notification.loading("Getting data from IPFS...");
+    let attempt = 0;
+    const maxAttempts = 2;
+    while (attempt < maxAttempts) {
+      try {
+        const metaData = await getMetadataFromIPFS(ipfsPath);
+        notification.remove(notificationId);
+        notification.success("Downloaded from IPFS");
+        setYourJSON(metaData);
+        break;
+      } catch (error) {
+        attempt++;
+        if (attempt < maxAttempts) {
+          notification.info(`Retrying download... (${attempt}/${maxAttempts})`);
+        } else {
+          notification.remove(notificationId);
+          notification.error("Error downloading from IPFS");
+          console.error("IPFS Download Error:", error);
+        }
+      }
     }
+    setLoading(false);
   };
 
   return (

--- a/packages/nextjs/app/ipfsUpload/page.tsx
+++ b/packages/nextjs/app/ipfsUpload/page.tsx
@@ -5,6 +5,7 @@ import type { NextPage } from "next";
 import { notification } from "~~/utils/scaffold-stark/notification";
 import { addToIPFS } from "~~/utils/simpleNFT/ipfs-fetch";
 import nftsMetadata from "~~/utils/simpleNFT/nftsMetadata";
+import { INITIAL_ATTEMPT, MAX_ATTEMPTS } from "~~/utils/simpleNFT/constants";
 
 const LazyReactJson = lazy(() => import("react-json-view"));
 
@@ -20,8 +21,8 @@ const IpfsUpload: NextPage = () => {
   const handleIpfsUpload = async () => {
     setLoading(true);
     const notificationId = notification.loading("Uploading to IPFS...");
-    let attempt = 0;
-    const maxAttempts = 2;
+    let attempt = INITIAL_ATTEMPT;
+    const maxAttempts = MAX_ATTEMPTS;
 
     while (attempt < maxAttempts) {
       try {

--- a/packages/nextjs/app/ipfsUpload/page.tsx
+++ b/packages/nextjs/app/ipfsUpload/page.tsx
@@ -20,19 +20,28 @@ const IpfsUpload: NextPage = () => {
   const handleIpfsUpload = async () => {
     setLoading(true);
     const notificationId = notification.loading("Uploading to IPFS...");
-    try {
-      const uploadedItem = await addToIPFS(yourJSON);
-      notification.remove(notificationId);
-      notification.success("Uploaded to IPFS");
+    let attempt = 0;
+    const maxAttempts = 2;
 
-      setUploadedIpfsPath(uploadedItem.path);
-    } catch (error) {
-      notification.remove(notificationId);
-      notification.error("Error uploading to IPFS");
-      console.log(error);
-    } finally {
-      setLoading(false);
+    while (attempt < maxAttempts) {
+      try {
+        const uploadedItem = await addToIPFS(yourJSON);
+        notification.remove(notificationId);
+        notification.success("Uploaded to IPFS");
+        setUploadedIpfsPath(uploadedItem.path);
+        break;
+      } catch (error) {
+        attempt++;
+        if (attempt < maxAttempts) {
+          notification.info(`Retrying upload... (${attempt}/${maxAttempts})`);
+        } else {
+          notification.remove(notificationId);
+          notification.error("Error uploading to IPFS");
+          console.error("IPFS Upload Error:", error);
+        }
+      }
     }
+    setLoading(false);
   };
 
   return (

--- a/packages/nextjs/utils/simpleNFT/constants.ts
+++ b/packages/nextjs/utils/simpleNFT/constants.ts
@@ -1,0 +1,2 @@
+export const INITIAL_ATTEMPT = 0;
+export const MAX_ATTEMPTS = 2;


### PR DESCRIPTION

Fixes #141 
## Types of change

- [ ] Feature
- [ ] Bug
- [x] Enhancement

## Comments (optional)
By adding retry mechanisms to both the addToIPFS and getMetadataFromIPFS functions, I’ve addressed the NFT duplication issue during fast minting on Sepolia. The retries ensure multiple attempts to handle delays or interruptions, reducing the chances of Token ID 1 being duplicated due to incomplete metadata processing
