### PR TITLE
Fixed the Hook useScaffoldEventHistory shows contract not found issue

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -232,7 +232,6 @@ export const useScaffoldEventHistory = <
 
   return {
     data: eventHistoryData,
-    // Include contract loading state in the isLoading status
     isLoading: isLoading || deployedContractLoading,
     error: error,
   };

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -80,13 +80,13 @@ export const useScaffoldEventHistory = <
       setIsLoading(false);
       return;
     }
-    
+
     setIsLoading(true);
     try {
       if (deployedContractLoading) {
         return;
       }
-      
+
       if (!deployedContractData) {
         throw new Error("Contract not found");
       }

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -76,14 +76,19 @@ export const useScaffoldEventHistory = <
   }, [targetNetwork.rpcUrls.public.http]);
 
   const readEvents = async (fromBlock?: bigint) => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+    
     setIsLoading(true);
     try {
+      if (deployedContractLoading) {
+        return;
+      }
+      
       if (!deployedContractData) {
         throw new Error("Contract not found");
-      }
-
-      if (!enabled) {
-        throw new Error("Hook disabled");
       }
 
       const event = (deployedContractData.abi as Abi).find(
@@ -227,7 +232,8 @@ export const useScaffoldEventHistory = <
 
   return {
     data: eventHistoryData,
-    isLoading: isLoading,
+    // Include contract loading state in the isLoading status
+    isLoading: isLoading || deployedContractLoading,
     error: error,
   };
 };


### PR DESCRIPTION
# Fixed the Hook useScaffoldEventHistory shows contract not found issue

Fixes #218

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## useScaffoldEventHistory changes:
 - do not read event if not enabled
 - wait for contract to be deplpoyed, then throw error if deployedContractData not found
 - proper isLoading state
