### PR TITLE
ci(speedrun): add challenge-6-stable-coin to sync list + workflow_dispatch

### DIFF
--- a/.github/workflows/sync_other_challenges.yaml
+++ b/.github/workflows/sync_other_challenges.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - base-challenge-template
+  workflow_dispatch: {}
 
 jobs:
   sync:
@@ -55,6 +56,7 @@ jobs:
             "challenge-3-dice-game"
             "challenge-4-build-a-dex"
             "challenge-5-multisig-wallet"
+            "challenge-6-stable-coin"
           )
 
           echo "Merging base-challenge-template into challenge branches..."


### PR DESCRIPTION
## Summary

Two surgical fixes to `.github/workflows/sync_other_challenges.yaml`:

1. **Add `challenge-6-stable-coin` to `CHALLENGE_BRANCHES`** — missing from the array, so it never auto-synced and drifted **6 scarb majors behind** (scarb 2.12.2 / sf 0.51.1 / devnet 0.6.1 vs base 2.18.0 / 0.60.0 / 0.8.1).
2. **Add `workflow_dispatch: {}`** — workflow was push-only; a recent run sat **queued ~2.5h** with no manual re-trigger path.

## Diff (only these two changes)

```
on:
   push:
     branches:
       - base-challenge-template
+  workflow_dispatch: {}

CHALLENGE_BRANCHES=(
             "challenge-3-dice-game"
             "challenge-4-build-a-dex"
             "challenge-5-multisig-wallet"
+            "challenge-6-stable-coin"
           )
```

No other workflow logic touched.

## Context

`challenge-6-stable-coin` was just manually caught up to base parity (OZ Cairo 3.0 + snforge_std 0.60 + SEPOLIA Alchemy fork + frontend `@starknet-react`→`@starknet-start` reconcile, `check-types` 0). At parity now, so adding it to auto-sync keeps it incrementally in sync. 5 pre-existing `test_myusd_engine` behavioral failures are challenge-author defects (proven on old toolchain too), tracked separately.

## Validation

`actionlint` PASS. 6 pre-existing SC2086 infos identical on pristine base — not introduced.

## Test plan

- [ ] After merge: `workflow_dispatch` the sync, confirm `challenge-6-stable-coin` processes cleanly (at parity)
- [ ] Confirm challenge-0..5 unchanged behavior