### PR TITLE
fix(contracts): migrate your_contract to OZ Cairo 3.0 + port SS2-135 premium fix

### DIFF
--- a/packages/snfoundry/contracts/src/your_contract.cairo
+++ b/packages/snfoundry/contracts/src/your_contract.cairo
@@ -77,15 +77,19 @@ pub mod YourContract {
                 Option::Some(amount_strk) => {
                     // In `Debug Contract` or UI implementation, call `approve` on STRK contract
                     // before invoking fn set_greeting()
-                    let strk_contract_address: ContractAddress = FELT_STRK_CONTRACT
-                        .try_into()
-                        .unwrap();
-                    let strk_dispatcher = IERC20Dispatcher {
-                        contract_address: strk_contract_address,
-                    };
-                    strk_dispatcher
-                        .transfer_from(get_caller_address(), get_contract_address(), amount_strk);
-                    self.premium.write(true);
+                    if amount_strk > 0 {
+                        let strk_contract_address: ContractAddress = FELT_STRK_CONTRACT
+                            .try_into()
+                            .unwrap();
+                        let strk_dispatcher = IERC20Dispatcher {
+                            contract_address: strk_contract_address,
+                        };
+                        strk_dispatcher
+                            .transfer_from(
+                                get_caller_address(), get_contract_address(), amount_strk,
+                            );
+                        self.premium.write(true);
+                    }
                 },
                 Option::None => { self.premium.write(false); },
             }
@@ -94,7 +98,7 @@ pub mod YourContract {
                     GreetingChanged {
                         greeting_setter: get_caller_address(),
                         new_greeting: self.greeting.read(),
-                        premium: true,
+                        premium: self.premium.read(),
                         value: amount_strk,
                     },
                 );

--- a/packages/snfoundry/contracts/src/your_contract.cairo
+++ b/packages/snfoundry/contracts/src/your_contract.cairo
@@ -9,7 +9,7 @@ pub trait IYourContract<TContractState> {
 #[starknet::contract]
 pub mod YourContract {
     use openzeppelin_access::ownable::OwnableComponent;
-    use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin_interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,


### PR DESCRIPTION
## Vấn đề

`base-challenge-template` **không build được** kể từ 2026-05-14. `scarb build` fail trên nhánh mặc định của một public repo, và CI (`Next.js CI` → step `Build Contracts`) đã đỏ liên tục từ đó.

## Nguyên nhân

Commit `11c01a2` (2026-05-14) sync `Scarb.toml` lên OpenZeppelin Cairo 3.0:

```
openzeppelin_token  >=3.0.0
openzeppelin_access >=3.0.0
```

Trong OZ Cairo 3.0, các ERC20 dispatcher đã chuyển khỏi `openzeppelin_token` sang crate riêng `openzeppelin_interfaces`. Nhưng `your_contract.cairo` không được migrate kèm — file này lần cuối được sửa 2025-09-05 (`f40cda6`).

**Tại sao sync không tự sửa được:** `scaffold-stark-2/.github/sync-speedrun-filter-rules` cố ý loại `packages/snfoundry/contracts/src/your_contract.cairo` khỏi rsync (mỗi challenge sở hữu bản riêng của mình), nhưng **không** loại `Scarb.toml`. Upstream commit `d589c42` sửa cả hai file cùng lúc — sync giao được nửa manifest và về mặt cấu trúc không thể giao nửa source. Không có lần sync nào sửa được việc này; bắt buộc phải làm tay.

## Thay đổi

Đúng **một dòng**, khớp chính xác với upstream `d589c42`:

```diff
- use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+ use openzeppelin_interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
```

## Vì sao chỉ một dòng, trong khi CI báo nhiều lỗi

Các lỗi còn lại đều là **hệ quả dây chuyền** của import hỏng này, không phải lỗi độc lập:

| Lỗi CI | Nguyên nhân |
|---|---|
| `E0002` `transfer_from` / `balance_of` / `transfer` not found | `IERC20Dispatcher` resolve thành `<missing>` |
| `E2313` ambiguous `TryInto` tại :104 | không suy ra được kiểu của `strk_contract_address` từ struct literal, nên target của `try_into` không xác định |
| 2 warning unused variable tại :80/:104 | cùng gốc |

Đã kiểm chứng: file tương ứng ở upstream có **y hệt** dòng `try_into().unwrap()` không annotate kiểu và vẫn compile bình thường. Không thêm type annotation nào.

## Kiểm chứng

```
scarb build        exit 0
scarb fmt --check  exit 0   (có chạy negative control để chứng minh check thật sự hoạt động)
snforge test       exit 0   Tests: 2 passed, 0 failed, 0 ignored, 0 filtered out
                            [PASS] test_contract::test_set_greetings
                            [PASS] test_contract::test_transfer
```

Fork test `SEPOLIA_LATEST` chạm mạng thật (`Latest block number = 12666650`) — quan trọng vì `test_transfer` chính là test đi qua `transfer_from` của import vừa migrate.

`Scarb.toml` và `Scarb.lock` **không bị đụng tới**. Versions resolve trên base: `openzeppelin_interfaces 2.1.0` (bản chứa segment `::token::`), `openzeppelin_token/access 3.0.0`, `snforge_std 0.62.1`, scarb 2.20.0.

> Đã rebase lên `8946c70`. Một commit thứ hai xoá `tests/TestContract.cairo` đã được git tự bỏ khi rebase — sync `8946c70` đã xoá file đó rồi sau khi upstream gỡ P rule (scaffold-stark-2#729).

## Commit 2 — port SS2-135 (bug `premium`)

Port **thủ công** từ upstream `6037c2b` / PR #648 — *"your contract set_greeting not updating premium"*. Một ticket có thật, không phải drift.

### Bug
```cairo
Option::None => { self.premium.write(false); }   // ghi premium = false
...
self.emit(GreetingChanged { premium: true, ... }); // nhưng event LUÔN báo true
```
Hai lỗi:
1. **Event nói dối** — `premium()` trả `false` nhưng event báo `true`. Ai index event nhận dữ liệu sai.
2. **Trả 0 đồng vẫn thành premium** — `Some(0)` chuyển 0 STRK nhưng vẫn ghi `premium = true`.

### Vì sao phải áp CẢ HAI hunk
- (a) bọc khối `transfer_from` + `premium.write(true)` vào `if amount_strk > 0 { }`
- (b) `premium: true` → `premium: self.premium.read()`

Chỉ áp (b) thì `Some(0)` vẫn chạy `premium.write(true)` vô điều kiện → `read()` trả `true` → event vẫn báo sai. **(b) một mình chỉ biến lời nói dối cứng thành một giá trị sai được báo cáo trung thực** — nhìn như đã sửa, bug còn nguyên. (a) mới làm giá trị trong storage đúng.

### Vì sao phải làm tay
`your_contract.cairo` bị `sync-speedrun-filter-rules` loại khỏi rsync (mỗi challenge có bản riêng). Upstream sửa từ **2025-09-05** nhưng bản sửa không có đường nào tới đây — **11 tháng**.

### Kiểm chứng mạnh nhất
```
diff <(git show upstream/develop:.../your_contract.cairo) .../your_contract.cairo
→ KHÔNG CÓ KHÁC BIỆT
```
File giờ **giống hệt byte-for-byte** với `upstream/develop`. Không còn drift nào.

```
scarb build 0 · scarb fmt --check 0 · snforge test 2 passed / 0 failed
```

> Không nhánh challenge nào có `your_contract.cairo` (đã kiểm tra: ch-0/2/3/5 = 0 file), nên PR này chỉ ảnh hưởng base.