### PR TITLE
fix(ch-3): migrate ERC20 dispatcher imports to openzeppelin_interfaces (OZ Cairo 3.0)

### DIFF
--- a/packages/snfoundry/.gitattributes
+++ b/packages/snfoundry/.gitattributes
@@ -1,7 +1,22 @@
 scripts-ts/helpers/** merge=theirs
 scripts-ts/deploy-contract.ts merge=theirs
 .env.example merge=theirs
+
+contracts/src/** merge=ours
+contracts/tests/** merge=ours
+scripts-ts/deploy.ts merge=ours
+
+# .gitattributes resolves conflicting patterns by last-match-wins, so any
+# override for a path under contracts/ must come after a broader contracts/**
+# rule. There is no such wildcard here anymore -- contracts/src/** and
+# contracts/tests/** above are scoped narrowly on purpose, see below.
 contracts/Scarb.lock merge=theirs
 
-contracts/** merge=ours
-scripts-ts/deploy.ts merge=ours
+# Scarb.toml intentionally has NO merge driver. Challenge branches carry
+# their own legitimate dependencies base doesn't have (e.g. challenge-6 keeps
+# openzeppelin_security on purpose for MyUSDStaking's ReentrancyGuard, see
+# commit c3a178d). merge=ours would silently freeze out base's version bumps;
+# merge=theirs would silently delete the challenge's own deps. Neither is
+# safe. Leaving it on the default 3-way merge means a real base/challenge
+# edit collides as a genuine conflict and the sync workflow opens a PR for a
+# human to resolve. Do NOT "fix" this by adding a driver.

--- a/packages/snfoundry/contracts/Scarb.lock
+++ b/packages/snfoundry/contracts/Scarb.lock
@@ -7,6 +7,7 @@ version = "0.2.0"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_interfaces",
+ "openzeppelin_testing",
  "openzeppelin_token",
  "openzeppelin_utils",
  "snforge_std",
@@ -35,6 +36,15 @@ source = "registry+https://scarbs.xyz/"
 checksum = "sha256:ee491981a69736cde220f8b7dd290b6d8620c85ee6b83c81f665f5bef78b62b1"
 dependencies = [
  "openzeppelin_interfaces",
+]
+
+[[package]]
+name = "openzeppelin_testing"
+version = "6.9.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:af4293370028d5a085964365f3f181a8f00bdef7c84c9db1c8b73582eaba891c"
+dependencies = [
+ "snforge_std",
 ]
 
 [[package]]

--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -9,6 +9,7 @@ edition = "2024_07"
 starknet = ">=2.12.0"
 openzeppelin_access = ">=2.0.0"
 openzeppelin_token = ">=2.0.0"
+openzeppelin_interfaces = ">=2.0.0, <3.0.0"
 
 [dev-dependencies]
 openzeppelin_utils = ">=2.0.0"

--- a/packages/snfoundry/contracts/src/dice_game.cairo
+++ b/packages/snfoundry/contracts/src/dice_game.cairo
@@ -1,4 +1,4 @@
-use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use openzeppelin_interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 
 #[starknet::interface]
 pub trait IDiceGame<T> {

--- a/packages/snfoundry/contracts/src/rigged_roll.cairo
+++ b/packages/snfoundry/contracts/src/rigged_roll.cairo
@@ -14,7 +14,7 @@ pub trait IRiggedRoll<T> {
 mod RiggedRoll {
     use core::keccak::keccak_u256s_le_inputs;
     use openzeppelin_access::ownable::OwnableComponent;
-    use openzeppelin_token::erc20::interface::IERC20DispatcherTrait;
+    use openzeppelin_interfaces::token::erc20::IERC20DispatcherTrait;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_block_number, get_caller_address, get_contract_address};
     use super::{IDiceGameDispatcher, IDiceGameDispatcherTrait};

--- a/packages/snfoundry/contracts/tests/test_contract.cairo
+++ b/packages/snfoundry/contracts/tests/test_contract.cairo
@@ -1,8 +1,8 @@
 use contracts::dice_game::{DiceGame, IDiceGameDispatcherTrait};
 use contracts::rigged_roll::{IRiggedRollDispatcher, IRiggedRollDispatcherTrait};
 use core::keccak::keccak_u256s_le_inputs;
+use openzeppelin_interfaces::token::erc20::IERC20DispatcherTrait;
 use openzeppelin_testing::declare_and_deploy;
-use openzeppelin_token::erc20::interface::IERC20DispatcherTrait;
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::cheatcodes::events::EventsFilterTrait;
 use snforge_std::{


### PR DESCRIPTION
## Vấn đề
`scarb build` exit 1 với **11 lỗi**. Nhánh hỏng từ 2026-05-14.

Trong OZ Cairo 3.0, `IERC20Dispatcher` chuyển từ `openzeppelin_token::erc20::interface` sang crate riêng `openzeppelin_interfaces`. Source chưa được migrate.

**Bump version KHÔNG sửa được.** `Scarb.lock` của nhánh đã resolve `openzeppelin_* 3.0.0` và `snforge_std 0.62.1` từ trước — floor `">=0.49.0"` là *vô hiệu*. Đã kiểm chứng: bump manifest thủ công rồi xoá lock và resolve lại cho ra **đúng 11 lỗi y hệt**.

Nguyên nhân nhánh trôi: sync 2026-05-14 CÓ bump Scarb.toml của ch-3 khớp base, nhưng mọi lần `Merge base-challenge-template` sau đó đều conflict ở Scarb.toml và **âm thầm giữ bản cũ** của ch-3 (do `contracts/** merge=ours`), trong khi các commit sync khác lại regenerate Scarb.lock độc lập — tạo ra lệch manifest/lock. Đây là hiện tượng máy móc, không ai quyết định cả.

## Thay đổi — 3 import site
| File | Cũ | Mới |
|---|---|---|
| `src/dice_game.cairo:1` | `openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait}` | `openzeppelin_interfaces::token::erc20::{...}` |
| `src/rigged_roll.cairo:17` | `openzeppelin_token::erc20::interface::IERC20DispatcherTrait` | `openzeppelin_interfaces::token::erc20::IERC20DispatcherTrait` |
| `tests/test_contract.cairo:5` | như trên | như trên |

Thêm `openzeppelin_interfaces = ">=2.0.0, <3.0.0"`, khớp base.

## Kiểm chứng
```
scarb build        exit 0     ← trước đây exit 1, 11 lỗi
scarb fmt --check  exit 0
snforge test       4 passed / 2 failed
```
`snforge_std` resolve `0.62.1`, không có version-requirement warning.

## ⚠️ 2 test fail là ĐÚNG — đó là đề bài
`test_rigged_roll_fails` và `test_rigged_roll_call_dice_game` đều truy về `RiggedRoll::rigged_roll()` tại `src/rigged_roll.cairo:56`:
```cairo
fn rigged_roll(ref self: ContractState, amount: u256) {}   // Checkpoint 3 — stub rỗng cố ý
```
Đây chính là phần learner phải tự implement. **Cố tình để nguyên.** Implement nó nghĩa là viết hộ lời giải.

PR này chỉ đưa nhánh về trạng thái build được.