### PR TITLE
fix(gitattributes): apply corrected merge drivers

### DIFF
--- a/packages/snfoundry/.gitattributes
+++ b/packages/snfoundry/.gitattributes
@@ -1,7 +1,22 @@
 scripts-ts/helpers/** merge=theirs
 scripts-ts/deploy-contract.ts merge=theirs
 .env.example merge=theirs
+
+contracts/src/** merge=ours
+contracts/tests/** merge=ours
+scripts-ts/deploy.ts merge=ours
+
+# .gitattributes resolves conflicting patterns by last-match-wins, so any
+# override for a path under contracts/ must come after a broader contracts/**
+# rule. There is no such wildcard here anymore -- contracts/src/** and
+# contracts/tests/** above are scoped narrowly on purpose, see below.
 contracts/Scarb.lock merge=theirs
 
-contracts/** merge=ours
-scripts-ts/deploy.ts merge=ours
+# Scarb.toml intentionally has NO merge driver. Challenge branches carry
+# their own legitimate dependencies base doesn't have (e.g. challenge-6 keeps
+# openzeppelin_security on purpose for MyUSDStaking's ReentrancyGuard, see
+# commit c3a178d). merge=ours would silently freeze out base's version bumps;
+# merge=theirs would silently delete the challenge's own deps. Neither is
+# safe. Leaving it on the default 3-way merge means a real base/challenge
+# edit collides as a genuine conflict and the sync workflow opens a PR for a
+# human to resolve. Do NOT "fix" this by adding a driver.


### PR DESCRIPTION
## Summary
- Applies the corrected `packages/snfoundry/.gitattributes` merge drivers (from `fix/sync-infra`) directly to this challenge branch.
- Manual application is required because the base branch protects `.gitattributes` with `merge=ours`, and the sync workflow reads `.gitattributes` from the checked-out challenge branch's working tree during merge — so a base-only fix never propagates here.

## What changed
- `Scarb.toml`: no merge driver (was previously missing/incorrect) — real base/challenge edits now surface as a genuine conflict for a human instead of silently dropping one side's changes.
- `Scarb.lock`: `merge=theirs`
- `contracts/src/**`, `contracts/tests/**`, `scripts-ts/deploy.ts`: `merge=ours`

## Test plan
- [x] `git check-attr merge` verified on Scarb.toml/Scarb.lock/src/tests/deploy.ts — matches expected values
- [x] `git diff --stat` confirms only `packages/snfoundry/.gitattributes` changed
- Not applicable: no compile/build needed, this only affects merge behavior