### PR TITLE
fix(ci): trigger CI on root yarn.lock/package.json changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
       - "packages/nextjs/**"
       - "yarn.lock"
       - "package.json"
+      - ".tool-versions"
   pull_request:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - "packages/snfoundry/**"
       - "yarn.lock"
       - "package.json"
+      - ".tool-versions"
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "packages/snfoundry/contracts/**"
       - "packages/nextjs/**"
+      - "yarn.lock"
+      - "package.json"
   pull_request:
     branches:
       - main
@@ -12,6 +14,8 @@ on:
     paths:
       - "packages/nextjs/**"
       - "packages/snfoundry/**"
+      - "yarn.lock"
+      - "package.json"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `.github/workflows/main.yml` path filters only covered `packages/snfoundry/contracts/**` and `packages/nextjs/**`, but `yarn.lock` and `package.json` live at the repo root.
- Pushes that only touch the root lockfile/manifest never triggered CI, even though the workflow runs `yarn install --immutable` (which fails on lockfile drift).
- Concretely: 4 PRs that updated `yarn.lock` merged around 11:30 UTC today with zero CI runs; the status dashboard stayed stuck at 10:21 UTC.
- Added `yarn.lock` and `package.json` to both the `push` and `pull_request` path filters so root dependency changes trigger CI.

## Test plan
- [x] Validated YAML syntax of the updated workflow file
- [ ] Confirm this PR's own CI run triggers (this PR itself touches only the workflow file, not the root lockfile, so verify by watching that a subsequent root `yarn.lock`/`package.json` change triggers a run)