### PR TITLE
fix(ch-3): migrate @starknet-react imports to @starknet-start — branch 500s and does not render

### DIFF
--- a/packages/nextjs/app/dice/page.tsx
+++ b/packages/nextjs/app/dice/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { NextPage } from "next";
-import { useBalance } from "@starknet-react/core";
+import { useBalance } from "@starknet-start/react";
 import { Roll, RollEvents } from "~~/components/RollEvents";
 import { Winner, WinnerEvents } from "~~/components/WinnerEvents";
 import { useScaffoldContract } from "~~/hooks/scaffold-stark/useScaffoldContract";
@@ -14,7 +14,7 @@ import {
   useScaffoldMultiWriteContract,
 } from "~~/hooks/scaffold-stark/useScaffoldMultiWriteContract";
 import { Address } from "~~/components/scaffold-stark";
-import { Address as AddressType } from "@starknet-react/chains";
+import { Address as AddressType } from "@starknet-start/chains";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-stark/useScaffoldEventHistory";
 import { BlockNumber } from "starknet";
 import useScaffoldStrkBalance from "~~/hooks/scaffold-stark/useScaffoldStrkBalance";

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Image from "next/image";
 import type { NextPage } from "next";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "@starknet-start/react";
 
 const Home: NextPage = () => {
   const connectedAddress = useAccount();

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -9,9 +9,9 @@ import { useOutsideClick } from "~~/hooks/scaffold-stark";
 import { CustomConnectButton } from "~~/components/scaffold-stark/CustomConnectButton";
 import { useTheme } from "next-themes";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
-import { devnet } from "@starknet-react/chains";
+import { devnet } from "@starknet-start/chains";
 import { SwitchTheme } from "./SwitchTheme";
-import { useAccount, useNetwork, useProvider } from "@starknet-react/core";
+import { useAccount, useNetwork, useProvider } from "@starknet-start/react";
 
 type HeaderMenuLink = {
   label: string;

--- a/packages/nextjs/components/RollEvents.tsx
+++ b/packages/nextjs/components/RollEvents.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Address } from "./scaffold-stark/Address";
-import { Address as AddressType } from "@starknet-react/chains";
+import { Address as AddressType } from "@starknet-start/chains";
 
 export type Roll = {
   address: AddressType;

--- a/packages/nextjs/components/WinnerEvents.tsx
+++ b/packages/nextjs/components/WinnerEvents.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Amount } from "~~/components/diceComponents/Amount";
-import { Address as AddressType } from "@starknet-react/chains";
+import { Address as AddressType } from "@starknet-start/chains";
 import { Address } from "~~/components/scaffold-stark";
 import { formatEther } from "ethers";
 

--- a/packages/nextjs/components/diceComponents/RollEvents.tsx
+++ b/packages/nextjs/components/diceComponents/RollEvents.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Address } from "~~/components/scaffold-stark";
-import { Address as AddressType } from "@starknet-react/chains";
+import { Address as AddressType } from "@starknet-start/chains";
 
 export type Roll = {
   address: AddressType;


### PR DESCRIPTION
`challenge-3-dice-game` currently returns **HTTP 500 and does not render at all**. Anyone who checks this branch out gets a blank page, not a working challenge.

### Cause

`packages/nextjs` imports from `@starknet-react/core` and `@starknet-react/chains`, but neither package is declared in `packages/nextjs/package.json` and neither appears in `yarn.lock`. `@starknet-start/react@1.0.8` does not depend on them either, so there is no transitive path to hoist from — the module simply cannot resolve.

This is a straggler from the `@starknet-react/*` → `@starknet-start/*` rename: `package.json` was migrated but these import sites were not.

### Verified empirically

Full `yarn install` → `yarn chain` → `yarn deploy` → `yarn start` against `origin/challenge-3-dice-game` (`8e21a932`):

| Route | Before | After |
|---|---|---|
| `/` | **500** — `Module not found: Can't resolve '@starknet-react/core'` (`app/page.tsx:4`) | **200** |
| `/dice` | **500** | **200** |

After the fix both routes serve real HTML with app chunks loading and no error boundary. `yarn deploy` succeeds against `starknet@^9.4.2`.

### The change

Import specifiers only — 6 files, 8 lines. Named imports are unchanged on both sides:

```diff
-import { useBalance } from "@starknet-react/core";
+import { useBalance } from "@starknet-start/react";
-import { Address as AddressType } from "@starknet-react/chains";
+import { Address as AddressType } from "@starknet-start/chains";
```

`useAccount`, `useNetwork`, `useProvider` and `useBalance` were each confirmed present in the export list of `@starknet-start/react@1.0.8`'s type definitions rather than assumed by API parity — `useBalance` in particular has no precedent on any already-migrated branch.

### Why not just add `@starknet-react/*` back to package.json

That would be a smaller diff but the wrong direction. Upstream `scaffold-stark-2` `develop` has zero `@starknet-react/*` references, and `base-challenge-template` and `challenge-6-stable-coin` are already fully migrated. Re-adding the old packages would deepen the split and drift further from every future sync.

No `@starknet-react` references remain in the tree. `challenge-1` and `challenge-2` are deliberately untouched — they declare both packages and are a genuinely different case.
