### PR TITLE
fix(ch-4): migrate @starknet-react imports to @starknet-start — branch 500s and does not render

### DIFF
--- a/packages/nextjs/app/dex/page.tsx
+++ b/packages/nextjs/app/dex/page.tsx
@@ -7,7 +7,7 @@ import { useScaffoldReadContract } from "~~/hooks/scaffold-stark/useScaffoldRead
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-stark/useScaffoldWriteContract";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-stark";
 import { multiplyTo1e18 } from "~~/utils/scaffold-stark/priceInWei";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "@starknet-start/react";
 import { formatEther } from "ethers";
 import { Address, Balance, IntegerInput } from "~~/components/scaffold-stark";
 import { Curve } from "~~/app/dex/_components";

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "@starknet-start/react";
 
 const Home = () => {
   const connectedAddress = useAccount();

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -14,9 +14,9 @@ import { useOutsideClick } from "~~/hooks/scaffold-stark";
 import { CustomConnectButton } from "~~/components/scaffold-stark/CustomConnectButton";
 import { useTheme } from "next-themes";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
-import { devnet } from "@starknet-react/chains";
+import { devnet } from "@starknet-start/chains";
 import { SwitchTheme } from "./SwitchTheme";
-import { useAccount, useNetwork, useProvider } from "@starknet-react/core";
+import { useAccount, useNetwork, useProvider } from "@starknet-start/react";
 
 type HeaderMenuLink = {
   label: string;


### PR DESCRIPTION
`challenge-4-build-a-dex` currently returns **HTTP 500 and does not render at all**. Anyone who checks this branch out gets a blank page, not a working challenge.

Same defect and same fix as #376 (`challenge-3-dice-game`).

### Cause

`packages/nextjs` imports from `@starknet-react/core` and `@starknet-react/chains`, but neither package is declared in `packages/nextjs/package.json` and neither appears in `yarn.lock`. `@starknet-start/react@1.0.8` does not depend on them either, so there is no transitive path to hoist from — the module simply cannot resolve.

This is a straggler from the `@starknet-react/*` → `@starknet-start/*` rename: `package.json` was migrated but these import sites were not.

### Verified empirically

Full `yarn install` → `yarn chain` → `yarn deploy` → `yarn start` against `origin/challenge-4-build-a-dex` (`430b66f6`):

| Route | Before | After |
|---|---|---|
| `/` | **500** — `Module not found: Can't resolve '@starknet-react/core'` | **200** |
| `/dex` | **500** | **200** |

After the fix both routes serve real HTML with no error boundary. `yarn deploy` succeeds against `starknet@^9.4.2` (Balloons + Dex deploy cleanly).

### The change

Import specifiers only — 3 files, 4 lines. Named imports are unchanged on both sides:

```diff
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "@starknet-start/react";
-import { devnet } from "@starknet-react/chains";
+import { devnet } from "@starknet-start/chains";
-import { useAccount, useNetwork, useProvider } from "@starknet-react/core";
+import { useAccount, useNetwork, useProvider } from "@starknet-start/react";
```

`useAccount`, `useNetwork` and `useProvider` were each confirmed present in the export list of `@starknet-start/react@1.0.8`'s type definitions rather than assumed by API parity.

### Why not just add `@starknet-react/*` back to package.json

That would be a smaller diff but the wrong direction. Upstream `scaffold-stark-2` `develop` has zero `@starknet-react/*` references, and `base-challenge-template` and `challenge-6-stable-coin` are already fully migrated. Re-adding the old packages would deepen the split and drift further from every future sync.

No `@starknet-react` references remain in the tree. `challenge-1` and `challenge-2` are deliberately untouched — they declare both packages and are a genuinely different case.
