### PR TITLE
docs(ch-1): document shared demo Alchemy key and stale .env trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ Your `Staker UI` tab should be almost done and working at this point.
 
 > Find the `packages/snfoundry/.env` file and fill the env variables related to Sepolia testnet with your own wallet account address and private key.
 
+> 💡 The RPC URL shipped in `.env.example` uses a shared demo Alchemy key. That's fine for a quick first run, but for anything sustained - a workshop, a long session, or a mainnet fork - grab your own free key from [Alchemy](https://www.alchemy.com/). The shared key has one rate limit across everyone using it, and when it throttles you won't see a "rate limited" error - you'll get an opaque parse or fork error and may think your own setup is broken.
+>
+> If you already have a `packages/snfoundry/.env` from an earlier clone, compare it against `.env.example` - `yarn install` never touches an existing `.env`, so a stale one may still point at the now-decommissioned `public.blastapi.io`. That failure won't say the endpoint is dead either; devnet just reports a raw parse error that looks like devnet itself is broken.
+
 ⛽️ You will need to get some `STRK` Sepolia tokens to deploy your contract to Sepolia testnet.
 
 > 📝 If you plan on submitting this challenge, be sure to set your deadline to at least block.timestamp + 72 hours


### PR DESCRIPTION
Adds a README note about the shared demo Alchemy key and the stale-`.env` trap.

No `Scarb.toml` change on this branch — its `[[tool.snforge.fork]]` url already points at the working Alchemy endpoint. The branches that needed that fix are challenge-0, challenge-2, challenge-3 and challenge-5.

### Why

`.env.example` ships a shared demo Alchemy key. That is deliberate — it makes the first run work with no signup — and it is an RPC gateway key, not a secret. The problem is scale: one key, one rate limit, shared by everyone. When it throttles, the error does **not** say "rate limited"; you get an opaque parse or fork error and reasonably conclude your own setup is broken.

There is a second, sharper trap. `postinstall` is `shx cp -n .env.example .env` — `-n` means it creates `.env` only if absent and **never** updates an existing one. Meanwhile `.env.example` *is* refreshed from upstream on every sync, while `.env` is excluded from it. That design is correct (never clobber a real key) but it means a long-lived clone drifts permanently. History of `packages/snfoundry/.env.example`:

```
2026-02-04  alchemy .../rpc/v0_10/
2025-10-30  alchemy .../rpc/v0_9/
2025-09-11  starknet-sepolia.public.blastapi.io/rpc/v0_9   <- decommissioned
2025-05-04  starknet-sepolia.public.blastapi.io/rpc/v0_8   <- decommissioned
2024-09-30  starknet-sepolia.public.blastapi.io/rpc/v0_7   <- decommissioned
```

The template only left Blast on 2025-10-30, so anyone who cloned and installed before then still has a `.env` pointing at a provider that now returns `{"code":-32000,"message":"Blast API is no longer available..."}`. Because that is a well-formed JSON-RPC envelope rather than a connection failure, starknet-devnet reports `data did not match any variant of untagged enum JsonRpcResponse` — which reads as devnet being broken. The README note names that string so it is greppable.

### Not changed, deliberately

`AGENTS.md`, `packages/nextjs/services/web3/websocket.ts`, `SKILLS.md`, `.env.example` and `scripts-ts/helpers/networks.ts` also referenced the dead endpoint. All are owned by `scaffold-stark-2` and copied over wholesale by the sync, so patching them here would be silently reverted. Upstream fixed them and the last sync delivered it — those files are already clean on this branch.

The `blastapi.io/faucets` link is a **different service** and is alive (HTTP 200). It is untouched. Only `*.public.blastapi.io/rpc/*` is dead.
